### PR TITLE
Fixes broken links on 4 different pages of site; couple link language updates

### DIFF
--- a/source/content/maps.mkd
+++ b/source/content/maps.mkd
@@ -44,7 +44,7 @@ These suggestions are specifically geared towards visually impaired users.
 ### Tools &amp; Resources
 
 * [A More Accessible Map](http://alistapart.com/article/cssmaps)
-* [Web Dragon: Making maps accessible. Why is theis map here?](http://www.webdragon.com.au/main-site/welcome/making-maps-accessible.-why-is-this-map-here;storyId,8171)
-* [W3C Accessible Maps](https://www.w3.org/WAI/RD/wiki/Accessible_Map)
+* [Web Dragon: Making maps accessible. Why is this map here?](http://www.webdragon.com.au/main-site/welcome/making-maps-accessible.-why-is-this-map-here;storyId,8171)
+* [W3C Accessible Maps](https://www.w3.org/WAI/RD/wiki/Accessible_Maps)
 * [Accessibility tip: Making maps accessible](http://www.accessiq.org/news/news/2015/03/accessibility-tip-making-maps-accessible)
-* [Maps](http://accessibility.psu.edu/images/maps/)
+* [Maps for Directions (with Google Maps)](http://accessibility.psu.edu/images/maps/)

--- a/source/design/animations.mkd
+++ b/source/design/animations.mkd
@@ -19,4 +19,4 @@ Animations with flickers or movement can trigger epileptic seizures.
 ### Tools &amp; Resources
 * [Three flashes or below threshold] (https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html)
 * [Girl Develop It Web Accessibility Slides/Curriculum] (http://girldevelopit.github.io/gdi-featured-accessibility/class1.html#/27)
-* [Girl Develop Web Accessibility GitHub Page] (https://github.com/girldevelopit/gdi-featured-accessibility/blob/master/class1.html)
+* [Girl Develop Web Accessibility GitHub Page] (https://github.com/girldevelopit/gdi-featured-accessibility)

--- a/source/design/color.mkd
+++ b/source/design/color.mkd
@@ -11,7 +11,7 @@ Find colors that provide maximum contrast, including enough contrast between con
 * **Color blindness:** Red/green color blindness is the most common, so avoid green on red or red on green. (Think especially about avoiding using red and green for "bad" and "good" indicators).
 
 ### Live Example
-From the [US Standards Website:](https://standards.usa.gov/visual-style/):
+From the [US Standards Website:](https://standards.usa.gov/colors/#text-accessibility):
 > "WCAG (Web Content Accessibility Guidelines) ensure that content is accessible by everyone, regardless of disability or user device. To meet these standards, text and interactive elements should have a color contrast ratio of at least 4.5:1. This ensures that viewers who cannot see the full color spectrum are able to read the text."
 
 > "The options below offer color palette combinations that fall within the range of Section 508 compliant foreground/background color contrast ratios."
@@ -159,7 +159,7 @@ From the [US Standards Website:](https://standards.usa.gov/visual-style/):
 * [Three common accessibility pitfalls for developers: colour contrast](http://simplyaccessible.com/article/pitfalls-colour-contrast/)
 * [What is Color Contrast?](http://a11yproject.com/posts/what-is-color-contrast)
 * [Colour Accessibility](https://24ways.org/2012/colour-accessibility/)
-* [US Standards Colors](https://standards.usa.gov/visual-style/#colors)
+* [US Standards Colors](https://standards.usa.gov/colors/)
 
 
 #### Testing Tools

--- a/source/design/font.mkd
+++ b/source/design/font.mkd
@@ -11,6 +11,6 @@ title: Typography | Accessibility Guidelines
 * **Spacing:** White space makes it easier for the user to know what to read and where to begin. Spacing between typographic elements should be open enough to feel light, but close enough to establish a proper relationship between elements.
 
 ### Tools &amp; Resources
-* [US Standards Text Accessibility] (https://standards.usa.gov/visual-style/#text-accessibility)
+* [US Standards Text Accessibility] (https://standards.usa.gov/colors/#text-accessibility)
 * [W3C Resize Text] (https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html)
 


### PR DESCRIPTION
The US design standards site was recently updated, and some of the urls for resources on the inclusion site now don't exist.  I've fixed broken links to point to real webpages, and also clarified some link language by updating text.
